### PR TITLE
Ensure https/http proxy works correctly.

### DIFF
--- a/lib/tent-status/app.rb
+++ b/lib/tent-status/app.rb
@@ -370,7 +370,7 @@ module Tent
       end
 
       def self_url_root
-        url = env['rack.url_scheme'] + "://" + env['HTTP_HOST']
+        url = (env['HTTP_X_FORWARDED_PROTO'] || env['rack.url_scheme']) + "://" + env['HTTP_HOST']
         if (port = self_port) && url !~ /:\d+\Z/
           url += ":#{port}"
         end


### PR DESCRIPTION
Similar to `tent/tentd-admin` pull request [#20](https://github.com/tent/tentd-admin/pull/20), this minor fix ensures a https/http reverse proxy works correctly.
